### PR TITLE
Update System.step to handle cases where no vertices are present

### DIFF
--- a/algovivo/System.js
+++ b/algovivo/System.js
@@ -216,14 +216,14 @@ class System {
     this.wasmInstance.exports.backward_euler_update(
       numVertices,
       
-      this.x1.ptr,
-      this.xGrad.ptr,
-      this.xTmp.ptr,
+      numVertices == 0 ? 0 : this.x1.ptr,
+      numVertices == 0 ? 0 : this.xGrad.ptr,
+      numVertices == 0 ? 0 : this.xTmp.ptr,
 
-      this.x0.ptr,
+      numVertices == 0 ? 0 : this.x0.ptr,
 
-      this.v0.ptr,
-      this.v1.ptr,
+      numVertices == 0 ? 0 : this.v0.ptr,
+      numVertices == 0 ? 0 : this.v1.ptr,
       
       this.h,
 
@@ -244,9 +244,11 @@ class System {
 
       vertexMass
     );
-
-    this.x0.slot.f32().set(this.x1.slot.f32());
-    this.v0.slot.f32().set(this.v1.slot.f32());
+    
+    if (numVertices != 0) {
+      this.x0.slot.f32().set(this.x1.slot.f32());
+      this.v0.slot.f32().set(this.v1.slot.f32());
+    }
   }
 
   dispose() {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -18,3 +18,15 @@ test("set x", async () => {
 
   expect(system.numVertices()).toBe(1);
 });
+
+test("step empty", async () => {
+  const wasmInstance = await utils.loadWasm();
+  const system = new algovivo.System({ wasmInstance });
+  expect(system.numVertices()).toBe(0);
+  expect(system.numSprings()).toBe(0);
+  expect(system.numTriangles()).toBe(0);
+  system.step();
+  expect(system.numVertices()).toBe(0);
+  expect(system.numSprings()).toBe(0);
+  expect(system.numTriangles()).toBe(0);
+});

--- a/test/system.test.js
+++ b/test/system.test.js
@@ -19,7 +19,7 @@ test("set x", async () => {
   expect(system.numVertices()).toBe(1);
 });
 
-test("step empty", async () => {
+test("step with no vertices", async () => {
   const wasmInstance = await utils.loadWasm();
   const system = new algovivo.System({ wasmInstance });
   expect(system.numVertices()).toBe(0);


### PR DESCRIPTION
`System.step` results in an error if there are no vertices in the simulation due to uninitialized tensors. This PR addresses this issue.