### PR TITLE
Update neural trajectory workflow

### DIFF
--- a/.github/workflows/render-trajectory.yml
+++ b/.github/workflows/render-trajectory.yml
@@ -29,6 +29,8 @@ jobs:
   generate-trajectory:
     runs-on: ubuntu-latest
     needs: build-wasm
+    env:
+      OUTPUT_DIRNAME: trajectory.out
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -38,10 +40,9 @@ jobs:
           name: algovivo.wasm
           path: build/
       - name: Generate trajectory frames
-        run: |
-          npm ci
-          npm run build
-          node test/neural/generateTrajectory.js
+        run: node test/neural/generateTrajectory.js
+      - name: Check trajectory output
+        run: test -d ${{ env.OUTPUT_DIRNAME }} || (echo "Directory does not exist" && exit 1)
   render-trajectory:
     runs-on: ubuntu-latest
     needs: generate-trajectory

--- a/.github/workflows/render-trajectory.yml
+++ b/.github/workflows/render-trajectory.yml
@@ -47,7 +47,7 @@ jobs:
           diff -r ${{ env.OUTPUT_DIRNAME }} test/neural/data/trajectory || (echo "Files do not match" && exit 1)
   render-trajectory:
     runs-on: ubuntu-latest
-    needs: generate-trajectory
+    needs: build-wasm
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/render-trajectory.yml
+++ b/.github/workflows/render-trajectory.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Generate trajectory frames
         run: node test/neural/generateTrajectory.js
       - name: Check trajectory output
-        run: test -d ${{ env.OUTPUT_DIRNAME }} || (echo "Directory does not exist" && exit 1)
+        run: |
+          test -d ${{ env.OUTPUT_DIRNAME }} || (echo "Directory does not exist" && exit 1)
+          diff -r ${{ env.OUTPUT_DIRNAME }} test/neural/data/trajectory || (echo "Files do not match" && exit 1)
   render-trajectory:
     runs-on: ubuntu-latest
     needs: generate-trajectory

--- a/.github/workflows/render-trajectory.yml
+++ b/.github/workflows/render-trajectory.yml
@@ -26,9 +26,25 @@ jobs:
         with:
           name: algovivo.wasm
           path: build/algovivo.wasm
-  render-trajectory:
+  generate-trajectory:
     runs-on: ubuntu-latest
     needs: build-wasm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Download WASM build
+        uses: actions/download-artifact@v3
+        with:
+          name: algovivo.wasm
+          path: build/
+      - name: Generate trajectory frames
+        run: |
+          npm ci
+          npm run build
+          node test/neural/generateTrajectory.js
+  render-trajectory:
+    runs-on: ubuntu-latest
+    needs: generate-trajectory
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/render-trajectory.yml
+++ b/.github/workflows/render-trajectory.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
           test -d ${{ env.OUTPUT_DIRNAME }} || (echo "Directory does not exist" && exit 1)
           diff -r ${{ env.OUTPUT_DIRNAME }} test/neural/data/trajectory || (echo "Files do not match" && exit 1)
+  # render-trajectory does not depend on generate-trajectory because render-trajectory uses the reference trajectory data
+  # which already exists in the repo, while generate-trajectory checks that the current version of the code generates the same
+  # trajectory that is already stored in the repo.
   render-trajectory:
     runs-on: ubuntu-latest
     needs: build-wasm

--- a/test/neural/generateTrajectory.js
+++ b/test/neural/generateTrajectory.js
@@ -36,7 +36,7 @@ async function main() {
   });
   policy.loadData(policyData);
 
-  const outputDirname = path.join(__dirname, "data", "trajectory");
+  const outputDirname = process.env.OUTPUT_DIRNAME || path.join(__dirname, "data", "trajectory");
 
   await utils.cleandir(outputDirname);
 


### PR DESCRIPTION
New job that runs `generateTrajectory.js` and checks its output against reference trajectory data.

```mermaid
graph LR;
build-wasm --> generate-trajectory
build-wasm --> render-trajectory
```

`render-trajectory` does not depend on `generate-trajectory` because `render-trajectory` uses the reference trajectory data which already exists in the repo, while `generate-trajectory` checks that the current version of the code generates the same trajectory that is already stored in the repo.